### PR TITLE
Switched plugin to org.apache.openejb.maven:tomee-maven-plugin

### DIFF
--- a/dukes-tomee/pom.xml
+++ b/dukes-tomee/pom.xml
@@ -29,11 +29,11 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.tomee.maven</groupId>
+                <groupId>org.apache.openejb.maven</groupId>
                 <artifactId>tomee-maven-plugin</artifactId>
-                <version>7.0.1</version>
+                <version>1.7.4</version>
                 <configuration>
-                    <tomeeClassifier>webprofile</tomeeClassifier>
+                    <tomeeClassifier>jaxrs</tomeeClassifier>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
This plugin is recommended on official TomEE site [here](http://tomee.apache.org/tomee-maven-plugin.html) and support more tiny tomeeClassifier `jaxrs`.
Simply run command:

```
maven clean install tomee:run
```

and then check URL `http://localhost:8080/dukes-tomee-1.0.0-SNAPSHOT/api/hello/`

Also given plugin support uber-jar by goal `tomee:exec` but I got strange exception during run

> The CATALINA_HOME environment variable is not defined correctly

P.S. Thanks for the cool session on JavaDay2016!
